### PR TITLE
Add new delivery carriers

### DIFF
--- a/SkipPay_OAS.yaml
+++ b/SkipPay_OAS.yaml
@@ -1359,11 +1359,8 @@ components:
       example: DELIVERY_CARRIER
     DeliveryCarrier:
       oneOf:
-        - $ref: '#/components/schemas/carrierId'
-        - $ref: '#/components/schemas/carrierCustom'
-      required:
-        - carrierId 
-        - carrierCustom
+        - $ref: '#/components/schemas/DeliveryCarrierPredefined'
+        - $ref: '#/components/schemas/DeliveryCarrierCustom'
     channel:
       title: channel
       enum:
@@ -1376,31 +1373,67 @@ components:
       description: 'Sales channel, indicates how or where the order is created. (ie. via e-mail, eshop or at a branch)'
       example: BRANCH
       default: ESHOP
-    carrierId:
-      title: carrierId
-      enum:
-        - CZ_POST_HAND
-        - CZ_POST_OFFICE
-        - CZ_POST_OTHER
-        - PPL
-        - DPD
-        - GEIS
-        - IN_TIME
-        - TOP_TRANS
-        - GEBRUDER_WEISS
-        - LOCAL_COURIER
-        - TNT
-        - GLS
-        - HDS_COMFORT
-        - HDS_STANDARD
-        - MALL_DEPOSIT
-      type: string
-      example: DPD
-    carrierCustom:
-      title: carrierCustom
-      type: string
-      maximum: 250
-      description: For carriers not found in enumeration of customer ID, specify value as text.     
+    DeliveryCarrierPredefined:
+      type: object
+      properties:
+        carrierId:
+          title: carrierId
+          enum:
+            - AIRWAY
+            - CZ_POST_HAND
+            - CZ_POST_OFFICE
+            - CZ_POST_OTHER
+            - DACHSER
+            - DB_SCHENKER
+            - DEUTSCHE_POST_DHL
+            - DHL
+            - DHL_EXPRESS
+            - DHL_FREIGHT
+            - DPD
+            - DSV
+            - FEDEX
+            - FOFR
+            - GEBRUDER_WEISS
+            - GEIS
+            - GLS
+            - HDS_COMFORT
+            - HDS_STANDARD
+            - IN_TIME
+            - JAPO_TRANSPORT
+            - LIFTAGO
+            - LOCAL_COURIER
+            - MAGYAR_POSTA
+            - MALL_DELIVERY
+            - MALL_DEPOSIT
+            - MESSENGER
+            - POSTA_BEZ_HRANIC
+            - PPL
+            - PPL_PARCEL_CONNECT
+            - RABEN
+            - SAMEDAY
+            - SDS
+            - SLOVAK_PARCEL_SERVICE
+            - SLOVENSKA_POSTA
+            - SPRING_GDS
+            - TNT
+            - TOP_TRANS
+            - UPS
+            - WEDO
+            - WEDO_ULOZENKA
+            - ZASILKOVNA
+          type: string
+          example: DPD
+      required:
+        - carrierId
+    DeliveryCarrierCustom:
+      properties:
+        carrierCustom:
+          title: carrierCustom
+          type: string
+          maximum: 250
+          description: For carriers not found in the enumeration of carrierId, specify the value as text.
+      required:
+        - carrierCustom
     DocumentSerializer:
       title: Document Serializer
       description: Type of the document


### PR DESCRIPTION
This PR adds new ENUM values of `deliveryCarrier.carrierId`. However, it also fixes the specs of `deliveryCarrier` itself...

At the moment, this is defined as `oneOf` between two references that happen to be `string`s. Originally, the references were named `DeliveryCarrierDefault` and `DeliveryCarrierCustom`. They were [later renamed](https://github.com/skip-pay/skippay-payments-API-OAS/pull/4) to `carrierId` and `carrierCustom` which created an illusion that these are object's properties while in fact they ramained strings. This could be seen in the sample "create application" POST request data: `"deliveryCarrier": "DPD"`, which doesn't have the expected structure.

The PR brings back the original reference names `DeliveryCarrierDefault` and `DeliveryCarrierCustom` but also changes them to objects, each having a different structure consisting of one (required) field, `carrierId` and `carrierCustom` respectively. The sample request data then correctly display as `"deliveryCarrier": {"carrierId": "DPD"}`. Also, the ENUM values which were not showing up in the API reference UI created by Docusaurus, now display as expected:

![Screenshot 2024-04-10 at 10 53 48](https://github.com/skip-pay/skippay-payments-API-OAS/assets/166377940/b7d52215-9f71-46d2-8ac1-9d7f545930c1)
